### PR TITLE
Mac support in CI (#591)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,29 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.4"
+matrix:
+  include:
+    - os: linux
+      python: 2.6
+    - os: linux
+      python: 2.7
+    - os: linux
+      python: 3.4
+    - os: osx
+      language: generic
+      env: PYTHON_INSTALLER=brew
+    - os: osx
+      language: generic
+      env: PYTHON_INSTALLER=pyenv TRAVIS_PYTHON_VERSION=2.7.14
+    - os: osx
+      language: generic
+      env: PYTHON_INSTALLER=pyenv TRAVIS_PYTHON_VERSION=3.6.4
+
 # command to install dependencies
 install:
-# develop seems to be required by travis since 02/2013
+  - source .travis/install.sh
+  - python --version
   - pip install PyYAML argparse rospkg vcstools catkin_pkg python-dateutil rosdistro
-  - python setup.py build develop
-  - pip install nose coverage flake8
+  - pip install -e .
+  - pip install nose coverage flake8 mock
 before_script:
   # stop the build if there are Python syntax errors or undefined names
   - if [ "${TRAVIS_PYTHON_VERSION}" != "2.6" ] ; then flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics; fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+do_install()
+{
+    set -e
+
+    if [[ $TRAVIS_OS_NAME == 'osx' && $PYTHON_INSTALLER == 'pyenv' ]]; then
+        brew install pyenv-virtualenv
+        pyenv versions
+        eval "$(pyenv init -)"
+        pyenv install $TRAVIS_PYTHON_VERSION
+        PYTHON_ENV_NAME=virtual-env-$TRAVIS_PYTHON_VERSION
+        pyenv virtualenv $TRAVIS_PYTHON_VERSION $PYTHON_ENV_NAME
+        pyenv activate $PYTHON_ENV_NAME
+
+    elif [[ $TRAVIS_OS_NAME == 'osx' && $PYTHON_INSTALLER == 'brew' ]]; then
+        # nose 1.3.7 creates /usr/local/man dir if it does not exist.
+        # The operation fails because current user does not own /usr/local.  Create the dir manually instead.
+        sudo mkdir /usr/local/man
+        sudo chown -R $(whoami) $(brew --prefix)/*
+
+        export PATH=$(pwd)/.travis/shim:$PATH
+
+        mkdir -p ~/Library/Python/2.7/lib/python/site-packages
+        echo "$(brew --prefix)/lib/python2.7/site-packages" >> ~/Library/Python/2.7/lib/python/site-packages/homebrew.pth
+    fi
+}
+
+do_install

--- a/.travis/shim/pip
+++ b/.travis/shim/pip
@@ -1,0 +1,6 @@
+#!/bin/sh
+# This wrapper allows installation to call pip and it actually be
+# the pip2 that's part of brewed Python, rather than the missing
+# system pip.
+pip2 $@
+exit $?


### PR DESCRIPTION
* Mac support (#1)

* Run CI on both linux and osx

* Introduce matrix for OSes with generic language for osx

* Matrix include does not recognize list of python versions.  Create an entry for every version

* Fix typo

* Remove empty line

* Install pyenv for osx

* Fix syntax error in the script

* Fix bash syntax error

* Remove set from the script

* Remove reference to the current directory while running install.sh

* Try v.env 2.7

* Print venv

* Install python with penv

* Fix typo in the scipt

* install mock

* Skip some tests on macOS

* Enable tests on linux to see the results

* Do not skip debian tests on mac - this is just wrong

* Fix test_dpkg_detect so it does not call apt-cache on Mac

* Fix test_AptInstalleso it does not call debian specific commands on Mac

* Fix test_rosdep_main.TestRosdepMain.test_install on Mac

* Print call_args_list for the first call in the test

* Change env. variable for python installation, make it consistent with TRAVIS

* Remove assert for the first command.  Order of parameters differs on various platforms.

* There is no version 3.4 in pyenv.  Use the latest in 3.4

* Match output with a run on Ubuntu

* Add EOL to the file

* Remove echo with python version env. variable

* Remove useless comment

* Switch Python for macOS to versions 2.7.14 and 3.6.4 to be consistent with the version installed by `brew python`

* Build and test on python installed from brew (#2)

Add a new job that uses python installed from brew.